### PR TITLE
Refresh only if at top of the page

### DIFF
--- a/reload.js
+++ b/reload.js
@@ -1,7 +1,9 @@
 function checkNewTweetsRefresh() {
   if(document.readyState != 'interactive') {
-    if(document.getElementsByClassName('js-new-tweets-bar').length > 0) {
-      document.getElementsByClassName('js-new-tweets-bar')[0].click();
+    if(document.body.scrollTop == 0) {
+      if(document.getElementsByClassName('js-new-tweets-bar').length > 0) {
+        document.getElementsByClassName('js-new-tweets-bar')[0].click();
+      }
     }
   }
   window.setTimeout('checkNewTweetsRefresh()', 1500);


### PR DESCRIPTION
This tiny change will prevent auto-refreshing if not at the top of the page, so no accidental refreshes while scrolling tweets